### PR TITLE
Add currency text to TicketOptions

### DIFF
--- a/src/components/TicketOptions.svelte
+++ b/src/components/TicketOptions.svelte
@@ -7,6 +7,7 @@
       title: 'Early Bird Pass',
       description: 'Limited Time Offer',
       price: '$700',
+      currency: 'NZD',
       cardClass: 'bg-success',
       buttonClass: 'bg-white'
     },
@@ -15,6 +16,7 @@
       description:
         'For secondary and tertiary students at any institution, and for people who are no longer in paid work.',
       price: '$500',
+      currency: 'NZD',
       cardClass: 'bg-white border-1 border-primary/50'
     },
     {
@@ -22,6 +24,7 @@
       description:
         'For open source, open data or volunteer community contributors otherwise not supported by another organisation to attend.',
       price: '$500',
+      currency: 'NZD',
       cardClass: 'bg-white border-1 border-primary/50'
     }
   ];
@@ -42,6 +45,7 @@
       </div>
       <div class="flex flex-1 items-end justify-end text-2xl sm:justify-normal">
         {tOption.price}
+        <span class="text-lg">{tOption.currency}</span>
       </div>
     </div>
     <div class="mt-4 flex justify-end sm:justify-normal">


### PR DESCRIPTION
At the moment we don't say what currency. Given NZD is cheaper than AU/US, it's probably a good idea to highlight. (should we have an approx equiv somewhere?)

old:

<img width="1160" alt="Screenshot 2025-07-01 at 11 18 24 AM" src="https://github.com/user-attachments/assets/9a8b2e54-7d69-472a-b36e-775f1a87d7cb" />

new:

<img width="1205" alt="Screenshot 2025-07-01 at 11 22 20 AM" src="https://github.com/user-attachments/assets/7cb55f25-c61d-467a-a8f0-a9c1841f6c9d" />

